### PR TITLE
Trim paths on builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TARGET_FOLDER=dist
 PACKAGE=$(APP)-$(VERSION)
 TAR_ARGS=cfz
 RELEASE_FILES=LICENSE README.md
-BUILD_OPTS=-ldflags="-s -w -X main.redressVersion=$(VERSION)" -gcflags="all=-trimpath=$(GOPATH)/src" -asmflags="-trimpath=$(GOPATH)/src"
+BUILD_OPTS=-ldflags="-s -w -X main.redressVersion=$(VERSION)" -trimpath
 
 # Linux options
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goretk/redress
 
-go 1.12
+go 1.13
 
 require (
 	github.com/TcM1911/r2g2 v0.1.0


### PR DESCRIPTION
Use the new build flag in 1.13 to trim flags.