### PR TITLE
Bug fix for note and set go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/TcM1911/r2g2 v0.1.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/goretk/gore v0.8.0
+	github.com/goretk/gore v0.8.1
 	github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/goretk/gore v0.8.0 h1:VmIQbe9vl3MmhZt1Hcu+NoqK6obVNZ/S9imdOiGHJ3w=
 github.com/goretk/gore v0.8.0/go.mod h1:feYF9BIRgr3SsMoGBRia9UaifmCTvlYXqM3DmjFLpRo=
+github.com/goretk/gore v0.8.1 h1:mVrOTmeD+fsvguzRI25e+HRjiVCRrdjDA83McYATHC0=
+github.com/goretk/gore v0.8.1/go.mod h1:feYF9BIRgr3SsMoGBRia9UaifmCTvlYXqM3DmjFLpRo=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type option struct {
 	printCompiler        *bool
 	printVersion         *bool
 	resolveStrSlice      *bool
+	forceVersion         *string
 }
 
 // This is set at compile time.
@@ -52,6 +53,7 @@ func init() {
 		options.printStructs = flag.Bool("struct", false, "Print structs")
 		options.printIntefaces = flag.Bool("interface", false, "Print interfaces")
 		options.printCompiler = flag.Bool("compiler", false, "Print information")
+		options.forceVersion = flag.String("force-version", "", "Forcing and using the given version when analyzing")
 	}
 	options.printMethods = flag.Bool("method", false, "Print type's methods")
 	options.printVersion = flag.Bool("version", false, "Print redress version")

--- a/standalone.go
+++ b/standalone.go
@@ -32,6 +32,14 @@ func standalone() {
 	}
 	defer f.Close()
 
+	// Setting forced version if given
+	if *options.forceVersion != "" {
+		if err = f.SetGoVersion(*options.forceVersion); err != nil {
+			fmt.Println("Failed to set the given Go version:", err)
+			return
+		}
+	}
+
 	if *options.printCompiler {
 		cmp, err := f.GetCompilerVersion()
 		if err != nil {


### PR DESCRIPTION
Update GoRE version to pull in a fix for missing note section in ELF
files.

Add flag to force an assumed Go version.