### PR TITLE
Display build info

### DIFF
--- a/info.go
+++ b/info.go
@@ -91,6 +91,13 @@ func listInfo(fileStr string) {
 		}
 	}
 
+	// Display extracted build information if it's available.
+	if f.BuildInfo != nil && f.BuildInfo.ModInfo != nil && len(f.BuildInfo.ModInfo.Settings) != 0 {
+		for _, set := range f.BuildInfo.ModInfo.Settings {
+			t.AddLine(set.Key, set.Value)
+		}
+	}
+
 	t.Print()
 }
 


### PR DESCRIPTION
This adds extracted information from the build environment as part of the info command. Example output:
```
OS            EM_X86_64
Arch          amd64
Compiler      1.20.2 (2023-03-07)
Main root     github.com/goretk/redress
-buildmode    exe
-compiler     gc
-trimpath     true
CGO_ENABLED   1
GOARCH        amd64
GOOS          linux
GOAMD64       v1
vcs           git
vcs.revision  222d2f3f80472c81154b040c94be2b6fad6b7e19
vcs.time      2022-05-20T09:21:35Z
vcs.modified  true
```