### PR TITLE
Add version override flag to type by offset

### DIFF
--- a/type.go
+++ b/type.go
@@ -99,9 +99,20 @@ func init() {
 			}
 			defer file.Close()
 
+			// If the user has provided a specific compiler version that we should assume,
+			// we force it.
+			if forceGoVersion != "" {
+				err = file.SetGoVersion(forceGoVersion)
+				if err != nil {
+					fmt.Println("Error when setting the assumed Go version:", err)
+					return
+				}
+			}
+
 			lookupType(file, addr)
 		},
 	}
+	typeOffsetCmd.Flags().StringVar(&forceGoVersion, "version", "", "Fallback compiler version.")
 
 	typCmd.AddCommand(typeOffsetCmd)
 	rootCmd.AddCommand(typCmd)


### PR DESCRIPTION
This adds the similar version override flag that exist in the parent command. If the user provides a compiler version with this flag, the provided compiler version is used when trying to extract the types.

Closes #24 