### PR TITLE
Refactor `listTypes` function to set Go version before retrieving types

### DIFF
--- a/type.go
+++ b/type.go
@@ -144,7 +144,7 @@ func listTypes(fileStr string, opts listTypesOptions) {
 
 	if opts.goversion != "" {
 		if err := f.SetGoVersion(opts.goversion); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to set goversion:", err)
+			fmt.Fprintln(os.Stderr, "Failed to set goversion:", err)
 			os.Exit(1)
 		}
 	}

--- a/type.go
+++ b/type.go
@@ -142,14 +142,17 @@ func listTypes(fileStr string, opts listTypesOptions) {
 	}
 	defer f.Close()
 
-	typs, err := f.GetTypes()
-	if err == gore.ErrNoGoVersionFound {
-		// Force the assumed version and try again.
-		f.SetGoVersion(opts.goversion)
-		typs, err = f.GetTypes()
+	if opts.goversion != "" {
+		if err := f.SetGoVersion(opts.goversion); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to set goversion:", err)
+			os.Exit(1)
+		}
 	}
+
+	var typs []*gore.GoType
+	typs, err = f.GetTypes()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error when enumerating types: %s.\n", err)
+		fmt.Fprintln(os.Stderr, "Error when enumerating types:", err, "\n\nUse --version to explicitly set it.")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This fixes #31, this problem comes up when the version is set but another error occurs like the version number being incorrect or another error when getting type info. The inner err was being shadowed here, so we get the old err.

- Moved the Go version setting logic to execute before calling `GetTypes`.
- Added error handling for setting the Go version.
- Improved error message formatting for type enumeration errors.

